### PR TITLE
Handle Missing 'author' in Bibtex Entries & Update Hash for Test Attachments

### DIFF
--- a/doi_to_org.py
+++ b/doi_to_org.py
@@ -259,8 +259,7 @@ class OrgEntry:
             except (FileError, KeyError): # bad luck, could not grab it, let's not attach anything
                 pass
 
-    def attach_file(self, file_name):
-        file_hash = self.attachment.hash
+    def attach_file(self, file_name, file_hash):
         org_dir = os.path.dirname(self.orgfile)
         data_dir = os.path.join(org_dir, 'data')
         os.makedirs(data_dir, exist_ok=True)
@@ -269,7 +268,6 @@ class OrgEntry:
         last_level_dir = os.path.join(first_level_dir, file_hash[2:])
         os.makedirs(last_level_dir) # if it already existed, this is a problem we want to know
         self.attachment.move_to(os.path.join(last_level_dir, file_name))
-        return file_hash
 
     def orgmode_from_bibentry(self, attached_file_name=None, attached_file_hash=None):
         header = '**** UNREAD {title}\t:PAPER:'
@@ -306,11 +304,13 @@ class OrgEntry:
     def add_entry(self):
         if self.attachment:
             attachment_name = self.generate_attachment_file_name()
-            attachment_hash = self.attach_file(attachment_name)
+            attachment_hash = self.attachment.hash
         else:
             attachment_name = None
             attachment_hash = None
         org_txt = self.orgmode_from_bibentry(attachment_name, attachment_hash)
+        if self.attachment:
+            self.attach_file(attachment_name, attachment_hash)
         with open(self.orgfile, 'a') as f:
             f.write(org_txt)
             f.write('\n')

--- a/doi_to_org.py
+++ b/doi_to_org.py
@@ -174,6 +174,12 @@ class BibError(Exception):
 class FileError(Exception):
     pass
 
+class MissingAuthorError(KeyError):
+    '''Raise when a bibtex entry is missing the "author" field'''
+    def __init__(self, message, *args):
+        self.message = message
+        super(MissingAuthorError, self).__init__(message, *args)
+
 class Attachment:
     def __init__(self, temporary_file):
         self.file = temporary_file
@@ -327,12 +333,6 @@ def org_entry_fabric(orgfile, arg):
         return [OrgEntry(orgfile, bib_entry, Attachment.from_arg(arg_list[1]))]
     else:
         raise SyntaxError('Wrong argument format, got %s.' % arg)
-
-class MissingAuthorError(KeyError):
-    '''Raise when a bibtex entry is missing the "author" field'''
-    def __init__(self, message, *args):
-        self.message = message
-        super(MissingAuthorError, self).__init__(message, *args)
 
 if __name__ == '__main__':
     if len(sys.argv) < 2:

--- a/test.py
+++ b/test.py
@@ -159,13 +159,13 @@ class AttachmentTest(Util):
 
     def test_url(self):
         self.generic_test(args=['https://hal.inria.fr/hal-01017319v2/bibtex'],
-                file_hash = '383dfc5b8f7430248cadbfa116d8e3b430907fcb2909a7a0ff2442996d174c215b2635934e3d3260bcb5b111ea6b8ebeadc987cf2d70aff7737cd5302e22ce05',
+                file_hash = 'dd544b94ad42c98728e4b382e47fcb7fc6772bed5158c74e205ebe0c44e712e546a4dadfc17050eda5acb1dbb11dcc03a3b984d966104a9ef85f8a0263f27bfc',
                 file_name = 'Versatile,_Scalable,_and_Accurate_Simulation_of_Distributed_Applications_and_Platforms.pdf',
                 expected_output_file = 'test_data/casanova_output.org')
 
     def test_hal(self):
         self.generic_test(args=['hal-01017319v2'],
-                file_hash = '383dfc5b8f7430248cadbfa116d8e3b430907fcb2909a7a0ff2442996d174c215b2635934e3d3260bcb5b111ea6b8ebeadc987cf2d70aff7737cd5302e22ce05',
+                file_hash = 'dd544b94ad42c98728e4b382e47fcb7fc6772bed5158c74e205ebe0c44e712e546a4dadfc17050eda5acb1dbb11dcc03a3b984d966104a9ef85f8a0263f27bfc',
                 file_name = 'Versatile,_Scalable,_and_Accurate_Simulation_of_Distributed_Applications_and_Platforms.pdf',
                 expected_output_file = 'test_data/casanova_output.org')
 

--- a/test.py
+++ b/test.py
@@ -59,6 +59,16 @@ class BibEntryTest(unittest.TestCase):
             warnings.filterwarnings("ignore", category=DeprecationWarning)
             self.assertEqual(bib.authors, 'Henri Casanova, Arnaud Giersch, Arnaud Legrand, Martin Quinson, Frédéric Suter')
 
+    def test_missing_author(self):
+        with open('test_data/casanova_missing_author_input.bib') as f:
+            bibtex = f.read()
+
+        bib_list = BibEntry.from_bibtex(bibtex)
+        org_entry = OrgEntry("", bib_list[0], attachment = True)
+
+        with self.assertRaises(SystemExit):
+           org_entry.orgmode_from_bibentry()
+
 class BasicCommandLineTest(Util):
     def test_doi(self):
         self.generic_test('10.1137/0206024', 'test_data/knuth_output.org')

--- a/test_data/casanova_missing_author_input.bib
+++ b/test_data/casanova_missing_author_input.bib
@@ -1,0 +1,15 @@
+@article{casanova:hal-01017319,
+    TITLE = "{Versatile, Scalable, and Accurate Simulation of Distributed Applications and Platforms}",
+    URL = "https://hal.inria.fr/hal-01017319",
+    JOURNAL = "{Journal of Parallel and Distributed Computing}",
+    PUBLISHER = "{Elsevier}",
+    VOLUME = "74",
+    NUMBER = "10",
+    PAGES = "2899-2917",
+    YEAR = "2014",
+    MONTH = "June",
+    DOI = "10.1016/j.jpdc.2014.06.008",
+    PDF = "https://hal.inria.fr/hal-01017319/file/simgrid3-journal.pdf",
+    HAL_ID = "hal-01017319",
+    HAL_VERSION = "v2"
+}

--- a/test_data/casanova_output.org
+++ b/test_data/casanova_output.org
@@ -4,7 +4,7 @@
 :URL: https://hal.inria.fr/hal-01017319
 :AUTHORS: Henri Casanova, Arnaud Giersch, Arnaud Legrand, Martin Quinson, Frédéric Suter
 :Attachments: Versatile,_Scalable,_and_Accurate_Simulation_of_Distributed_Applications_and_Platforms.pdf
-:ID: 383dfc5b8f7430248cadbfa116d8e3b430907fcb2909a7a0ff2442996d174c215b2635934e3d3260bcb5b111ea6b8ebeadc987cf2d70aff7737cd5302e22ce05
+:ID: dd544b94ad42c98728e4b382e47fcb7fc6772bed5158c74e205ebe0c44e712e546a4dadfc17050eda5acb1dbb11dcc03a3b984d966104a9ef85f8a0263f27bfc
 :END:
 ***** Summary
 ***** Notes


### PR DESCRIPTION
These two commits implement error handling for bibtex entries with a missing 'author' field and update the file hashes for test attachments.